### PR TITLE
[FEATURE] get translationByLocale of AttributeValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu Product Bundle
 
 * dev-develop
 
+    * FEATURE     Added function that ProductValueAttribute translation can be retrieved by a gitven locale.
     * FEATURE     Added many-to-many releation `variantAttributes` between product and attributes
     * FEATURE     Added github templates for issues and pull-requests.
     * FEATURE     Added style-ci configuration.

--- a/Entity/AttributeValue.php
+++ b/Entity/AttributeValue.php
@@ -88,7 +88,7 @@ class AttributeValue
      *
      * @param string $locale
      *
-     * @return \Doctrine\Common\Collections\Collection|null
+     * @return AttributeValueTranslation|null
      */
     public function getTranslationByLocale($locale)
     {

--- a/Entity/AttributeValue.php
+++ b/Entity/AttributeValue.php
@@ -84,6 +84,24 @@ class AttributeValue
     }
 
     /**
+     * Get translation by locale.
+     *
+     * @param string $locale
+     *
+     * @return \Doctrine\Common\Collections\Collection|null
+     */
+    public function getTranslationByLocale($locale)
+    {
+        foreach ($this->getTranslations() as $valueTranslation) {
+            if ($valueTranslation->getLocale() === $locale) {
+                return $valueTranslation;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Set attribute.
      *
      * @param \Sulu\Bundle\ProductBundle\Entity\Attribute $attribute


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Entity method to retrieve translated AttributeValues of a product by a given locale.

#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)

#### Example Usage

~~~php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

$foo = new Foo();

// Now we can do
$foo->doSomething();
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR

