### PR TITLE
[BUGFIX] Fixed wrong path to get action schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu Product Bundle
 
 * dev-develop
 
+    * BUGFIX      Fixed wrong path to get action schema.
     * FEATURE     Added validation schema for get products api.
 
 * 0.15.0 (2016-09-26)

--- a/DependencyInjection/SuluProductExtension.php
+++ b/DependencyInjection/SuluProductExtension.php
@@ -56,7 +56,7 @@ class SuluProductExtension extends Extension implements PrependExtensionInterfac
                 'sulu_validation',
                 [
                     'schemas' => [
-                        'get_product' => '@SuluProductBundle/Validation/Product/getActionSchema.json',
+                        'get_product' => '@SuluProductBundle/Validation/Products/getActionSchema.json',
                     ],
                 ]
             );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

Fixed wrong path of get action schema of get product by id

