### PR TITLE
[BUGFIX] Fixed setting attributes of value 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 
 php:
   - 5.5
+  - 7.0
 
 env:
   - DB=mysql
@@ -15,4 +16,4 @@ before_script:
   - if [[ "$DB" == "mysql" ]]; then mysql -e "CREATE DATABASE sulu_test;"; fi
   - vendor/symfony-cmf/testing/bin/console doctrine:schema:create
 
-script: phpunit --coverage-text
+script: phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG for Sulu Product Bundle
 =================================
 
+* 0.16.3 (2016-11-22)
+
+    * BUGFIX      Fixed setting attributes of value '0'.
+
 * 0.16.2 (2016-11-04)
 
     * BUGFIX      Resolved wrong locale in xliff file.

--- a/Product/ProductManager.php
+++ b/Product/ProductManager.php
@@ -2009,7 +2009,7 @@ class ProductManager implements ProductManagerInterface
                 }
 
                 // If attribute value is empty do not add.
-                if (!$attributeDataValueName) {
+                if ('' === $attributeDataValueName || null === $attributeDataValueName) {
                     // If already set on product, remove attribute value translation.
                     if (array_key_exists($attributeId, $productAttributes)) {
                         /** @var ProductAttribute $productAttribute */

--- a/Tests/Functional/Controller/ProductControllerTest.php
+++ b/Tests/Functional/Controller/ProductControllerTest.php
@@ -1028,6 +1028,10 @@ class ProductControllerTest extends SuluTestCase
                     'attributeId' => $this->productAttribute2->getAttribute()->getId(),
                     'attributeValueName' => $this->attributeValueTranslation2->getName(),
                 ],
+                2 => [
+                    'attributeId' => $this->productAttribute2->getAttribute()->getId(),
+                    'attributeValueName' => 0,
+                ],
             ],
         ];
 
@@ -1035,8 +1039,10 @@ class ProductControllerTest extends SuluTestCase
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 
         $response = json_decode($this->client->getResponse()->getContent());
+        $this->assertCount(3, $response->attributes);
         $this->assertEquals('EnglishAttributeValue-1', $response->attributes[0]->attributeValueName);
         $this->assertEquals('EnglishAttributeValue-2', $response->attributes[1]->attributeValueName);
+        $this->assertEquals('0', $response->attributes[2]->attributeValueName);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes setting attributes of value '0'

#### Why?

Previously, when setting an attribute to a product with value '0', the relation was deleted. Now a value translation '0' is created.
