### PR TITLE
Fix typo in read me config default_formatter_locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sulu_route:
 sulu_product:
     category_root_key: ~
     default_currency: 'EUR'
-    default_formatter_locale 'en'
+    default_formatter_locale: 'en'
     display_recurring_prices: true
     fallback_locale: de
     fixtures:


### PR DESCRIPTION
Fix typo
default_formatter_locale 'en' => default_formatter_locale: 'en'

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### Fixed typo in read me file


#### There is a type in read me file

Under 
sulu_product:
    default_formatter_locale 'en'

It should be 

sulu_product:
    default_formatter_locale: 'en'
