### PR TITLE
Add countBy and pagination to the product family repository

### DIFF
--- a/src/Domain/Repository/ProductFamilyRepositoryInterface.php
+++ b/src/Domain/Repository/ProductFamilyRepositoryInterface.php
@@ -22,6 +22,8 @@ use Sulu\Product\Domain\Model\ProductFamilyInterface;
  *     uuids?: string[],
  *     externalIdentifier?: string,
  *     productUuid?: string,
+ *     page?: int,
+ *     limit?: int,
  * }
  */
 interface ProductFamilyRepositoryInterface
@@ -39,6 +41,13 @@ interface ProductFamilyRepositoryInterface
      * @return iterable<ProductFamilyInterface>
      */
     public function findBy(array $filters = []): iterable;
+
+    /**
+     * The page and limit filters are ignored, they are stripped before counting.
+     *
+     * @param ProductFamilyRepositoryFilters $filters
+     */
+    public function countBy(array $filters = []): int;
 
     /**
      * @param ProductFamilyRepositoryFilters $filters

--- a/src/Domain/Repository/ProductRepositoryInterface.php
+++ b/src/Domain/Repository/ProductRepositoryInterface.php
@@ -108,8 +108,10 @@ interface ProductRepositoryInterface
      *     limit?: int,
      * } $filters
      * @param array{
-     *     id?: 'asc'|'desc',
+     *     uuid?: 'asc'|'desc',
      *     title?: 'asc'|'desc',
+     *     created?: 'asc'|'desc',
+     *     position?: 'asc'|'desc',
      * } $sortBy
      * @param array{
      *     product_admin?: bool,
@@ -143,8 +145,10 @@ interface ProductRepositoryInterface
      *     limit?: int,
      * } $filters
      * @param array{
-     *     id?: 'asc'|'desc',
+     *     uuid?: 'asc'|'desc',
      *     title?: 'asc'|'desc',
+     *     created?: 'asc'|'desc',
+     *     position?: 'asc'|'desc',
      * } $sortBy
      *
      * @return iterable<string>

--- a/src/Infrastructure/Doctrine/Repository/ProductFamilyRepository.php
+++ b/src/Infrastructure/Doctrine/Repository/ProductFamilyRepository.php
@@ -86,6 +86,22 @@ final class ProductFamilyRepository implements ProductFamilyRepositoryInterface
         return $result;
     }
 
+    public function countBy(array $filters = []): int
+    {
+        // The countBy method will ignore any page and limit parameters
+        // for better developer experience we will strip them away here
+        // instead of that the developer need to take that into account
+        // in there call of the countBy method.
+        unset($filters['page']); // @phpstan-ignore-line
+        unset($filters['limit']); // @phpstan-ignore-line
+
+        $queryBuilder = $this->createQueryBuilder($filters);
+
+        $queryBuilder->select('COUNT(DISTINCT productFamily.id)');
+
+        return (int) $queryBuilder->getQuery()->getSingleScalarResult();
+    }
+
     /**
      * @param ProductFamilyRepositoryFilters $filters
      */
@@ -131,6 +147,20 @@ final class ProductFamilyRepository implements ProductFamilyRepositoryInterface
                 ->setParameter('stage', DimensionContentInterface::STAGE_DRAFT)
                 ->setParameter('version', DimensionContentInterface::CURRENT_VERSION)
                 ->setParameter('productUuid', $productUuid);
+        }
+
+        $limit = $filters['limit'] ?? null;
+        if (null !== $limit) {
+            Assert::integer($limit); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            $queryBuilder->setMaxResults($limit);
+        }
+
+        $page = $filters['page'] ?? null;
+        if (null !== $page) {
+            Assert::integer($page); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            Assert::notNull($limit);
+            $offset = (int) ($limit * ($page - 1));
+            $queryBuilder->setFirstResult($offset);
         }
 
         return $queryBuilder;

--- a/tests/Functional/Repository/ProductFamilyRepositoryTest.php
+++ b/tests/Functional/Repository/ProductFamilyRepositoryTest.php
@@ -160,6 +160,74 @@ class ProductFamilyRepositoryTest extends SuluTestCase
         $this->assertCount(1, $result);
     }
 
+    public function testFindByLimitAndPageReturnsTheRequestedSlice(): void
+    {
+        for ($i = 0; $i < 5; ++$i) {
+            $this->repository->save($this->repository->create());
+        }
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $firstPage = [];
+        foreach ($this->repository->findBy(['page' => 1, 'limit' => 2]) as $family) {
+            $firstPage[] = $family;
+        }
+
+        $secondPage = [];
+        foreach ($this->repository->findBy(['page' => 2, 'limit' => 2]) as $family) {
+            $secondPage[] = $family;
+        }
+
+        $lastPage = [];
+        foreach ($this->repository->findBy(['page' => 3, 'limit' => 2]) as $family) {
+            $lastPage[] = $family;
+        }
+
+        $this->assertCount(2, $firstPage);
+        $this->assertCount(2, $secondPage);
+        $this->assertCount(1, $lastPage);
+
+        $uuids = \array_map(
+            static fn (ProductFamilyInterface $family) => $family->getUuid(),
+            [...$firstPage, ...$secondPage, ...$lastPage],
+        );
+        $this->assertCount(5, \array_unique($uuids));
+    }
+
+    public function testCountByCountsAllFamilies(): void
+    {
+        $this->repository->save($this->repository->create());
+        $this->repository->save($this->repository->create());
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $this->assertSame(2, $this->repository->countBy());
+    }
+
+    public function testCountByAppliesTheFilters(): void
+    {
+        $family = $this->repository->create();
+        $family->setExternalIdentifier('shoes');
+        $this->repository->save($family);
+        $this->repository->save($this->repository->create());
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $this->assertSame(1, $this->repository->countBy(['externalIdentifier' => 'shoes']));
+        $this->assertSame(0, $this->repository->countBy(['externalIdentifier' => 'hats']));
+    }
+
+    public function testCountByIgnoresPageAndLimit(): void
+    {
+        for ($i = 0; $i < 3; ++$i) {
+            $this->repository->save($this->repository->create());
+        }
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $this->assertSame(3, $this->repository->countBy(['page' => 1, 'limit' => 1]));
+    }
+
     public function testFindOneByReturnsNullForUnknownUuid(): void
     {
         $this->assertNull($this->repository->findOneBy(['uuid' => '00000000-0000-0000-0000-000000000000']));


### PR DESCRIPTION
Closes #408, for the parts of it that are still open.

Some of the issue has landed since it was written, so I checked the current state of `3.0` before touching anything:

- `ProductFamilyRepositoryInterface::findBy()` already exists, added by #407 the day after the issue;
- `AttributeRepositoryInterface::countBy()` already exists too.

What is left, and what this does:

- **`ProductFamilyRepositoryInterface::countBy()`**, mirroring `ProductRepositoryInterface::countBy()` down to stripping `page` and `limit` before counting, so a caller can reuse the same filter array for both calls. It counts `DISTINCT productFamily.id`, since the `productUuid` filter joins the dimension content.
- **`page` and `limit`** in `ProductFamilyRepositoryFilters`, implemented the same way as in `ProductRepository::createQueryBuilder()`. That is what a paginated list tool needs, and it was the missing half of `findBy()`.

### The `$sortBy` I did not add

The issue suggests `array{name?: ..., created?: ...} $sortBy`, and neither key exists on the entity: `ProductFamily` maps `id`, `uuid`, `externalIdentifier` and `defaultLocale`, with no `created`, and the name lives on `ProductFamilyTranslation`, so ordering by it means joining the translation for a given locale. A `$sortBy` that only accepts `uuid` would be a poor API, and a locale-aware one is a design decision rather than a gap to fill, so I left it out. Happy to add it in whichever shape you want.

### The phpdoc that lies, from the last section of the issue

`ProductRepositoryInterface::findBy()` and `findIdentifiersBy()` advertise `id` as a `$sortBy` key. Nothing handles `id`: `ProductRepository::createQueryBuilder()` maps `uuid`, `created` and `position`, and `DimensionContentQueryEnhancer` handles `title`, `authored`, `workflowPublished`, `created` and `changed` when the locale and stage filters are set. So `['id' => 'desc']` is accepted and silently ignored, while `created` and `position` work but are undocumented.

Both interfaces now carry the same shape the concrete `createQueryBuilder()` already documents: `uuid`, `title`, `created`, `position`. The enhancer-only keys are left out, since they depend on filters being set.

### Verification

Four functional tests added to `ProductFamilyRepositoryTest`: the paginated slices add up without overlap, `countBy()` counts everything, applies filters, and ignores `page` and `limit`. Full suite green (1321 tests), PHPStan and PHP-CS-Fixer clean.
