### PR TITLE
Add own URLs for Product Variants and Simple Products avoid URL for Product with Variant ( main product )

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ sulu_product:
     route:
         type: route # default, e.g. "page_tree_route" for a route below a page
         params:
-            route_schema: "/products/{implode('-', object)}"
+            route_schema: "/products/{implode('-', object)}" # default
 ```
 
 `params` takes any key the configured field type understands and forwards it to the field as-is;
 `route_schema` is the one the `route` field reads to generate the URL out of the fields tagged
 `sulu.rlp.part`. A param configured here wins over the same param declared in the form XML. Both
 forms get the same type and the same params.
+
+`route_schema` defaults to the value above, so a product URL starts with `/products/` without any
+configuration. A project overrides that key or adds params of its own, and the default stays for
+every key the project does not set.
 
 The same field is added invisibly to every product template, because `RoutableDataMapper` of the
 content package reads the route property off the template metadata. A template declaring its own

--- a/README.md
+++ b/README.md
@@ -29,21 +29,10 @@ content package reads the route property off the template metadata. A template d
 
 ## Variant URLs
 
-A variant owns no route of its own. Referenced from a page, it resolves to its parent's URL plus a
-query parameter carrying the variant code, so `/products/cable` with code `XY-2` resolves to
-`/products/cable?variant=XY-2`.
-
-The bundle only writes that URL — nothing reads the parameter back off the request. A project
-selects the variant itself, which makes the key a contract between both sides: change it under
-`sulu_product.variant_query_parameter` and the reading side has to match by hand.
-
-```yaml
-sulu_product:
-    variant_query_parameter: 'variant' # default
-```
-
-A variant whose parent has no published route in the requested locale resolves without a `url`,
-because an empty string would point at the site root.
+A variant owns its route: the URL field is mandatory on the variant overlay, so every variant
+carries an address of its own. A product with variants owns none, it is reached through its
+variants, which is why the field is hidden for that type and the route guard drops one that
+reaches such a product programmatically.
 
 ## Association form overrides
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ sulu_product:
 `sulu.rlp.part`. A param configured here wins over the same param declared in the form XML. Both
 forms get the same type and the same params.
 
+The same field is added invisibly to every product template, because `RoutableDataMapper` of the
+content package reads the route property off the template metadata. A template declaring its own
+`url` property keeps it and only receives the configured type and params.
+
 ## Variant URLs
 
 A variant owns no route of its own. Referenced from a page, it resolves to its parent's URL plus a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # Sulu Product Bundle
 
+## Product route
+
+The route field of a product lives in the `product_details` form and in the `product_variant`
+overlay, not in the product template. Its field type and its params are configured once for the
+whole project, so a form does not repeat them:
+
+```yaml
+sulu_product:
+    route:
+        type: route # default, e.g. "page_tree_route" for a route below a page
+        params:
+            route_schema: "/products/{implode('-', object)}"
+```
+
+`params` takes any key the configured field type understands and forwards it to the field as-is;
+`route_schema` is the one the `route` field reads to generate the URL out of the fields tagged
+`sulu.rlp.part`. A param configured here wins over the same param declared in the form XML. Both
+forms get the same type and the same params.
+
 ## Variant URLs
 
 A variant owns no route of its own. Referenced from a page, it resolves to its parent's URL plus a

--- a/config/forms/Product/product_details.xml
+++ b/config/forms/Product/product_details.xml
@@ -14,6 +14,16 @@
             <params>
                 <param name="headline" value="true"/>
             </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="route" colspan="12">
+            <meta>
+                <title>sulu_product.url</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
         </property>
 
         <property name="code" type="text_line" colspan="6">

--- a/config/forms/Product/product_details.xml
+++ b/config/forms/Product/product_details.xml
@@ -18,7 +18,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="route" colspan="12">
+        <property name="url" type="route">
             <meta>
                 <title>sulu_product.url</title>
             </meta>

--- a/config/forms/Product/product_details.xml
+++ b/config/forms/Product/product_details.xml
@@ -6,7 +6,7 @@
     <key>product_details</key>
 
     <properties>
-        <property name="type" type="single_select" mandatory="true" colspan="4" disabledCondition="!!id or url" >
+        <property name="type" type="single_select" mandatory="true" colspan="4" disabledCondition="!!id or url">
             <!-- as soon as an URL generated we can not allow to switch back as emptying an URL is not possible -->
             <meta>
                 <title>sulu_product.product_type</title>

--- a/config/forms/Product/product_details.xml
+++ b/config/forms/Product/product_details.xml
@@ -6,45 +6,8 @@
     <key>product_details</key>
 
     <properties>
-        <property name="title" type="text_line" mandatory="true" colspan="12">
-            <meta>
-                <title>sulu_admin.name</title>
-            </meta>
-
-            <params>
-                <param name="headline" value="true"/>
-            </params>
-
-            <tag name="sulu.rlp.part"/>
-        </property>
-
-        <property name="url" type="route">
-            <meta>
-                <title>sulu_product.url</title>
-            </meta>
-
-            <tag name="sulu.rlp"/>
-        </property>
-
-        <property name="code" type="text_line" colspan="6">
-            <meta>
-                <title>sulu_product.code</title>
-            </meta>
-        </property>
-
-        <property name="status" type="single_select" colspan="6">
-            <meta>
-                <title>sulu_product.status</title>
-            </meta>
-        </property>
-
-        <property name="productFamily" type="single_product_family_selection" mandatory="true" colspan="6" disabledCondition="!!id" multilingual="false">
-            <meta>
-                <title>sulu_product.product_family</title>
-            </meta>
-        </property>
-
-        <property name="type" type="single_select" mandatory="true" colspan="6" disabledCondition="!!id">
+        <property name="type" type="single_select" mandatory="true" colspan="4" disabledCondition="!!id or url" >
+            <!-- as soon as an URL generated we can not allow to switch back as emptying an URL is not possible -->
             <meta>
                 <title>sulu_product.product_type</title>
             </meta>
@@ -64,6 +27,48 @@
                     </param>
                 </param>
             </params>
+        </property>
+
+        <property name="productFamily" type="single_product_family_selection" mandatory="true" colspan="4" disabledCondition="!!id" multilingual="false">
+            <meta>
+                <title>sulu_product.product_family</title>
+            </meta>
+        </property>
+
+        <property name="status" type="single_select" colspan="4">
+            <meta>
+                <title>sulu_product.status</title>
+            </meta>
+        </property>
+
+        <property name="title" type="text_line" mandatory="true" colspan="8">
+            <meta>
+                <title>sulu_admin.name</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="code" type="text_line" colspan="4">
+            <meta>
+                <title>sulu_product.code</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+        </property>
+
+        <property name="url" type="route" colspan="12" visibleCondition="type != 'product_with_variants'">
+            <meta>
+                <title>sulu_product.url</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
         </property>
 
         <property name="externalIdentifier" type="text_line" colspan="12"

--- a/config/forms/Product/product_variant.xml
+++ b/config/forms/Product/product_variant.xml
@@ -18,7 +18,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="route" colspan="12">
+        <property name="url" type="route">
             <meta>
                 <title>sulu_product.url</title>
             </meta>

--- a/config/forms/Product/product_variant.xml
+++ b/config/forms/Product/product_variant.xml
@@ -14,6 +14,16 @@
             <params>
                 <param name="headline" value="true"/>
             </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="route" colspan="12">
+            <meta>
+                <title>sulu_product.url</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
         </property>
 
         <property name="code" type="text_line" mandatory="true" colspan="6">

--- a/src/Domain/Model/ProductDimensionContent.php
+++ b/src/Domain/Model/ProductDimensionContent.php
@@ -131,6 +131,14 @@ class ProductDimensionContent implements ProductDimensionContentInterface
         return false;
     }
 
+    /**
+     * @internal
+     */
+    public function removeRoute(): void
+    {
+        $this->route = null;
+    }
+
     public static function getResourceKey(): string
     {
         return ProductInterface::RESOURCE_KEY;

--- a/src/Domain/Model/ProductDimensionContentInterface.php
+++ b/src/Domain/Model/ProductDimensionContentInterface.php
@@ -31,6 +31,11 @@ interface ProductDimensionContentInterface extends DimensionContentInterface, Ex
 {
     public const DEFAULT_STATUS = 'available';
 
+    /**
+     * @internal
+     */
+    public function removeRoute(): void;
+
     public function getTitle(): ?string;
 
     public function setTitle(?string $title): static;

--- a/src/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuard.php
+++ b/src/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuard.php
@@ -52,12 +52,9 @@ class ProductWithVariantsRouteGuard
 
             $entity->removeRoute();
 
-            $metadata = $entityManager->getClassMetadata($entity::class);
-            if ($unitOfWork->isScheduledForInsert($entity)) {
-                $unitOfWork->computeChangeSet($metadata, $entity);
-            } else {
-                $unitOfWork->recomputeSingleEntityChangeSet($metadata, $entity);
-            }
+            // Recompute, never compute: a second computeChangeSet() on a scheduled insert replaces
+            // its full changeset with a one-field diff, leaving the INSERT short of bound values.
+            $unitOfWork->recomputeSingleEntityChangeSet($entityManager->getClassMetadata($entity::class), $entity);
 
             if ($unitOfWork->isScheduledForInsert($route)) {
                 $entityManager->detach($route);

--- a/src/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuard.php
+++ b/src/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuard.php
@@ -59,7 +59,6 @@ class ProductWithVariantsRouteGuard
                 $unitOfWork->recomputeSingleEntityChangeSet($metadata, $entity);
             }
 
-            // a route the same flush would insert has no owner left
             if ($unitOfWork->isScheduledForInsert($route)) {
                 $entityManager->detach($route);
             }

--- a/src/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuard.php
+++ b/src/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuard.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Infrastructure\Doctrine\EventListener;
+
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
+use Sulu\Product\Domain\Model\ProductInterface;
+use Sulu\Route\Domain\Model\Route;
+
+/**
+ * A product with variants is reached through its variants, so it never owns a route. Dropped on
+ * flush rather than in the form, so no programmatic write can leave one behind.
+ *
+ * @internal
+ */
+class ProductWithVariantsRouteGuard
+{
+    public function onFlush(OnFlushEventArgs $eventArgs): void
+    {
+        $entityManager = $eventArgs->getObjectManager();
+        $unitOfWork = $entityManager->getUnitOfWork();
+
+        $entities = [
+            ...$unitOfWork->getScheduledEntityInsertions(),
+            ...$unitOfWork->getScheduledEntityUpdates(),
+        ];
+
+        foreach ($entities as $entity) {
+            if (!$entity instanceof ProductDimensionContentInterface) {
+                continue;
+            }
+
+            $route = $entity->getRoute();
+            if (!$route instanceof Route) {
+                continue;
+            }
+
+            if (!$entity->getResource()->isType(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS)) {
+                continue;
+            }
+
+            $entity->removeRoute();
+
+            $metadata = $entityManager->getClassMetadata($entity::class);
+            if ($unitOfWork->isScheduledForInsert($entity)) {
+                $unitOfWork->computeChangeSet($metadata, $entity);
+            } else {
+                $unitOfWork->recomputeSingleEntityChangeSet($metadata, $entity);
+            }
+
+            // a route the same flush would insert has no owner left
+            if ($unitOfWork->isScheduledForInsert($route)) {
+                $entityManager->detach($route);
+            }
+        }
+    }
+}

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Infrastructure\Sulu\Admin;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Product\Domain\Model\ProductInterface;
+
+/**
+ * Applies the `sulu_product.route` configuration to the route field of the product form, so a
+ * project sets the route type and its params (e.g. `route_schema`) once instead of per form.
+ *
+ * @internal
+ */
+class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface
+{
+    private const FORM_KEYS = [ProductInterface::FORM_KEY, ProductInterface::FORM_KEY_VARIANT];
+
+    private const FIELD_NAME = 'url';
+
+    /**
+     * @param array<string, scalar|null> $params
+     */
+    public function __construct(
+        private readonly string $type,
+        private readonly array $params,
+    ) {
+    }
+
+    public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void
+    {
+        if (!\in_array($formMetadata->getKey(), self::FORM_KEYS, true)) {
+            return;
+        }
+
+        $routeField = $formMetadata->getItems()[self::FIELD_NAME] ?? null;
+        if (!$routeField instanceof FieldMetadata) {
+            return;
+        }
+
+        $routeField->setType($this->type);
+
+        foreach ($this->params as $name => $value) {
+            $option = new OptionMetadata();
+            $option->setName($name);
+            $option->setValue($value);
+
+            // addOption is keyed by name, so a configured param replaces the one of the form
+            $routeField->addOption($option);
+        }
+    }
+}

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -17,15 +17,23 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
+use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
+use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
- * Applies the `sulu_product.route` configuration to the route field of the product form, so a
+ * Applies the `sulu_product.route` configuration to the route field of the product forms, so a
  * project sets the route type and its params (e.g. `route_schema`) once instead of per form.
+ *
+ * The product templates get the same field invisibly, because RoutableDataMapper reads the route
+ * property off the template metadata while the editable field lives in the product forms.
  *
  * @internal
  */
-class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface
+class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, TypedFormMetadataVisitorInterface
 {
     private const FORM_KEYS = [ProductInterface::FORM_KEY, ProductInterface::FORM_KEY_VARIANT];
 
@@ -51,6 +59,31 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface
             return;
         }
 
+        $this->applyRouteConfig($routeField);
+    }
+
+    public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        if (ProductDimensionContent::getTemplateType() !== $key) {
+            return;
+        }
+
+        foreach ($formMetadata->getForms() as $form) {
+            $routeField = $form->getItems()[self::FIELD_NAME] ?? null;
+
+            if (!$routeField instanceof FieldMetadata) {
+                $routeField = new FieldMetadata(self::FIELD_NAME);
+                $routeField->setVisibleCondition('false');
+                $form->addItem($routeField);
+            }
+
+            $this->applyRouteConfig($routeField);
+            $this->skipTemplateData($routeField);
+        }
+    }
+
+    private function applyRouteConfig(FieldMetadata $routeField): void
+    {
         $routeField->setType($this->type);
 
         foreach ($this->params as $name => $value) {
@@ -61,5 +94,20 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface
             // addOption is keyed by name, so a configured param replaces the one of the form
             $routeField->addOption($option);
         }
+    }
+
+    /**
+     * The slug belongs to the route entity. Tagged here rather than left to the visitor of the
+     * content package, whose order against this one is not defined.
+     */
+    private function skipTemplateData(FieldMetadata $routeField): void
+    {
+        if ($routeField->hasTag(TemplateDataMapper::SKIP_TAG)) {
+            return;
+        }
+
+        $tag = new TagMetadata();
+        $tag->setName(TemplateDataMapper::SKIP_TAG);
+        $routeField->addTag($tag);
     }
 }

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -20,6 +20,9 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductInterface;
@@ -59,6 +62,15 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
         }
 
         $this->applyRouteConfig($routeField);
+
+        if (ProductInterface::FORM_KEY_VARIANT !== $formMetadata->getKey()) {
+            return;
+        }
+
+        $routeField->setRequired(true);
+        $formMetadata->setSchema($formMetadata->getSchema()->merge(new SchemaMetadata([
+            new PropertyMetadata(self::FIELD_NAME, true, new StringMetadata(1)),
+        ])));
     }
 
     public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -20,9 +20,6 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductInterface;
@@ -68,9 +65,6 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
         }
 
         $routeField->setRequired(true);
-        $formMetadata->setSchema($formMetadata->getSchema()->merge(new SchemaMetadata([
-            new PropertyMetadata(self::FIELD_NAME, true, new StringMetadata(1)),
-        ])));
     }
 
     public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -95,7 +95,7 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
         foreach ($this->params as $name => $value) {
             $option = new OptionMetadata();
             $option->setName($name);
-            $option->setValue($value);
+            $option->setValue(\is_float($value) ? (string) $value : $value);
 
             $routeField->addOption($option);
         }

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -38,6 +38,8 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
 
     private const RESOURCE_LOCATOR_TAG = 'sulu.rlp';
 
+    private const SEARCH_FIELD_ROLE = 'url';
+
     /**
      * @param array<string, scalar|null> $params
      */
@@ -80,6 +82,7 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
                 $routeField = new FieldMetadata(self::FIELD_NAME);
                 $routeField->setVisibleCondition('false');
                 $this->addTag($routeField, self::RESOURCE_LOCATOR_TAG);
+                $this->addTag($routeField, TagMetadata::SEARCH_FIELD_TAG, ['role' => self::SEARCH_FIELD_ROLE]);
                 $form->addItem($routeField);
             }
 
@@ -101,7 +104,10 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
         }
     }
 
-    private function addTag(FieldMetadata $routeField, string $name): void
+    /**
+     * @param array<string, string> $attributes
+     */
+    private function addTag(FieldMetadata $routeField, string $name, array $attributes = []): void
     {
         foreach ($routeField->getTags() as $tag) {
             if ($tag->getName() === $name) {
@@ -111,6 +117,7 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
 
         $tag = new TagMetadata();
         $tag->setName($name);
+        $tag->setAttributes($attributes);
         $routeField->addTag($tag);
     }
 }

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -25,11 +25,8 @@ use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
- * Applies the `sulu_product.route` configuration to the route field of the product forms, so a
- * project sets the route type and its params (e.g. `route_schema`) once instead of per form.
- *
- * The product templates get the same field invisibly, because RoutableDataMapper reads the route
- * property off the template metadata while the editable field lives in the product forms.
+ * Applies the `sulu_product.route` configuration to the route field of the product forms, and adds
+ * the same field invisibly to the product templates, where RoutableDataMapper reads it.
  *
  * @internal
  */
@@ -81,8 +78,6 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
             }
 
             $this->applyRouteConfig($routeField);
-
-            // the slug belongs to the route entity, so it never becomes template data
             $this->addTag($routeField, TemplateDataMapper::SKIP_TAG);
         }
     }
@@ -96,16 +91,10 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
             $option->setName($name);
             $option->setValue($value);
 
-            // addOption is keyed by the option name, so a configured param overwrites the
-            // one the form or the template declares
             $routeField->addOption($option);
         }
     }
 
-    /**
-     * A tag of the same name is merged, keeping the priority and the attributes the form or the
-     * template declares, because FieldMetadata::addTag appends and would carry a second one.
-     */
     private function addTag(FieldMetadata $routeField, string $name): void
     {
         foreach ($routeField->getTags() as $tag) {

--- a/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitor.php
@@ -39,6 +39,8 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
 
     private const FIELD_NAME = 'url';
 
+    private const RESOURCE_LOCATOR_TAG = 'sulu.rlp';
+
     /**
      * @param array<string, scalar|null> $params
      */
@@ -74,11 +76,14 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
             if (!$routeField instanceof FieldMetadata) {
                 $routeField = new FieldMetadata(self::FIELD_NAME);
                 $routeField->setVisibleCondition('false');
+                $this->addTag($routeField, self::RESOURCE_LOCATOR_TAG);
                 $form->addItem($routeField);
             }
 
             $this->applyRouteConfig($routeField);
-            $this->skipTemplateData($routeField);
+
+            // the slug belongs to the route entity, so it never becomes template data
+            $this->addTag($routeField, TemplateDataMapper::SKIP_TAG);
         }
     }
 
@@ -91,23 +96,26 @@ class ProductRouteFormMetadataVisitor implements FormMetadataVisitorInterface, T
             $option->setName($name);
             $option->setValue($value);
 
-            // addOption is keyed by name, so a configured param replaces the one of the form
+            // addOption is keyed by the option name, so a configured param overwrites the
+            // one the form or the template declares
             $routeField->addOption($option);
         }
     }
 
     /**
-     * The slug belongs to the route entity. Tagged here rather than left to the visitor of the
-     * content package, whose order against this one is not defined.
+     * A tag of the same name is merged, keeping the priority and the attributes the form or the
+     * template declares, because FieldMetadata::addTag appends and would carry a second one.
      */
-    private function skipTemplateData(FieldMetadata $routeField): void
+    private function addTag(FieldMetadata $routeField, string $name): void
     {
-        if ($routeField->hasTag(TemplateDataMapper::SKIP_TAG)) {
-            return;
+        foreach ($routeField->getTags() as $tag) {
+            if ($tag->getName() === $name) {
+                return;
+            }
         }
 
         $tag = new TagMetadata();
-        $tag->setName(TemplateDataMapper::SKIP_TAG);
+        $tag->setName($name);
         $routeField->addTag($tag);
     }
 }

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -402,7 +402,7 @@ final class SuluProductBundle extends AbstractBundle
         $builder->setParameter('sulu_product.variant_query_parameter', $variantQueryParameter);
 
         /** @var array{type: string, params: array<string, scalar|null>} $route */
-        $route = $config['route'] ?? ['type' => 'route', 'params' => []];
+        $route = $config['route'];
         $builder->setParameter('sulu_product.route.type', $route['type']);
         $builder->setParameter('sulu_product.route.params', $route['params']);
 

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -244,11 +244,13 @@ final class SuluProductBundle extends AbstractBundle
                             ->cannotBeEmpty()
                         ->end()
                         ->arrayNode('params')
-                            ->info('Params passed to the route field, e.g. "route_schema". Params configured here win over the ones the form declares.')
+                            ->info('Params passed to the route field. A configured param wins over the one the form declares, and over the default of the same key.')
                             ->normalizeKeys(false)
                             ->useAttributeAsKey('name')
                             ->scalarPrototype()->end()
-                            ->defaultValue([])
+                            ->defaultValue([
+                                'route_schema' => "/products/{implode('-', object)}",
+                            ])
                         ->end()
                     ->end()
                 ->end()

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -905,7 +905,8 @@ final class SuluProductBundle extends AbstractBundle
                 '%sulu_product.route.type%',
                 '%sulu_product.route.params%',
             ])
-            ->tag('sulu_admin.form_metadata_visitor');
+            ->tag('sulu_admin.form_metadata_visitor')
+            ->tag('sulu_admin.typed_form_metadata_visitor');
 
         $services->set('sulu_product.products_list_metadata_visitor')
             ->class(ProductsListMetadataVisitor::class)

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -182,6 +182,14 @@ final class SuluProductBundle extends AbstractBundle
     use PersistenceExtensionTrait;
 
     /**
+     * Merged into the configured params, because the default of a prototyped node is replaced by
+     * the params a project sets instead of merged with them.
+     */
+    private const DEFAULT_ROUTE_PARAMS = [
+        'route_schema' => "/products/{implode('-', object)}",
+    ];
+
+    /**
      * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function configure(DefinitionConfigurator $definition): void
@@ -249,9 +257,10 @@ final class SuluProductBundle extends AbstractBundle
                             ->normalizeKeys(false)
                             ->useAttributeAsKey('name')
                             ->scalarPrototype()->end()
-                            ->defaultValue([
-                                'route_schema' => "/products/{implode('-', object)}",
-                            ])
+                            ->defaultValue(self::DEFAULT_ROUTE_PARAMS)
+                            ->validate()
+                                ->always(static fn (array $params): array => [...self::DEFAULT_ROUTE_PARAMS, ...$params])
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -109,6 +109,7 @@ use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductDetailsFieldMetadataValidator;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductFamilyAdmin;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductRouteFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductsListMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductStatusFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductVariantAttributeFormMetadataVisitor;
@@ -232,6 +233,24 @@ final class SuluProductBundle extends AbstractBundle
                     ->info('Query parameter a variant URL carries, e.g. /product/xy?variant=XY-2.')
                     ->defaultValue('variant')
                     ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('route')
+                    ->info('Field type and params of the route field in the "product_details" and "product_variant" forms.')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('type')
+                            ->info('Field type of the route field, e.g. "route" or "page_tree_route".')
+                            ->defaultValue('route')
+                            ->cannotBeEmpty()
+                        ->end()
+                        ->arrayNode('params')
+                            ->info('Params passed to the route field, e.g. "route_schema". Params configured here win over the ones the form declares.')
+                            ->normalizeKeys(false)
+                            ->useAttributeAsKey('name')
+                            ->scalarPrototype()->end()
+                            ->defaultValue([])
+                        ->end()
+                    ->end()
                 ->end()
                 ->arrayNode('association_types')
                     ->info('Custom product association types (e.g. "alternative", "suitable"). Omit the whole section to disable association types.')
@@ -369,6 +388,11 @@ final class SuluProductBundle extends AbstractBundle
         /** @var string $variantQueryParameter */
         $variantQueryParameter = $config['variant_query_parameter'] ?? 'variant';
         $builder->setParameter('sulu_product.variant_query_parameter', $variantQueryParameter);
+
+        /** @var array{type: string, params: array<string, scalar|null>} $route */
+        $route = $config['route'] ?? ['type' => 'route', 'params' => []];
+        $builder->setParameter('sulu_product.route.type', $route['type']);
+        $builder->setParameter('sulu_product.route.params', $route['params']);
 
         $services = $container->services();
 
@@ -873,6 +897,14 @@ final class SuluProductBundle extends AbstractBundle
 
         $services->set('sulu_product.product_code_form_metadata_visitor')
             ->class(ProductCodeFormMetadataVisitor::class)
+            ->tag('sulu_admin.form_metadata_visitor');
+
+        $services->set('sulu_product.product_route_form_metadata_visitor')
+            ->class(ProductRouteFormMetadataVisitor::class)
+            ->args([
+                '%sulu_product.route.type%',
+                '%sulu_product.route.params%',
+            ])
             ->tag('sulu_admin.form_metadata_visitor');
 
         $services->set('sulu_product.products_list_metadata_visitor')

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -93,6 +93,7 @@ use Sulu\Product\Domain\Repository\AttributeGroupRepositoryInterface;
 use Sulu\Product\Domain\Repository\AttributeRepositoryInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
 use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
+use Sulu\Product\Infrastructure\Doctrine\EventListener\ProductWithVariantsRouteGuard;
 use Sulu\Product\Infrastructure\Doctrine\Repository\AttributeGroupRepository;
 use Sulu\Product\Infrastructure\Doctrine\Repository\AttributeRepository;
 use Sulu\Product\Infrastructure\Doctrine\Repository\ProductFamilyRepository;
@@ -900,6 +901,10 @@ final class SuluProductBundle extends AbstractBundle
         $services->set('sulu_product.product_code_form_metadata_visitor')
             ->class(ProductCodeFormMetadataVisitor::class)
             ->tag('sulu_admin.form_metadata_visitor');
+
+        $services->set('sulu_product.product_with_variants_route_guard')
+            ->class(ProductWithVariantsRouteGuard::class)
+            ->tag('doctrine.event_listener', ['event' => 'onFlush']);
 
         $services->set('sulu_product.product_route_form_metadata_visitor')
             ->class(ProductRouteFormMetadataVisitor::class)

--- a/tests/Application/config/templates/products/default.xml
+++ b/tests/Application/config/templates/products/default.xml
@@ -29,16 +29,6 @@
             <tag name="sulu.search.field" role="title"/>
         </property>
 
-        <property name="url" type="route">
-            <meta>
-                <title lang="en">Resourcelocator</title>
-                <title lang="de">Adresse</title>
-            </meta>
-
-            <tag name="sulu.rlp"/>
-            <tag name="sulu.search.field" role="url"/>
-        </property>
-
         <property name="description" type="text_area">
             <meta>
                 <title lang="en">Description</title>

--- a/tests/Functional/Integration/ProductControllerTest.php
+++ b/tests/Functional/Integration/ProductControllerTest.php
@@ -226,6 +226,44 @@ class ProductControllerTest extends SuluTestCase
         ]));
     }
 
+    public function testPostProductWithVariantsWithUrlCreatesNoRoute(): void
+    {
+        self::purgeDatabase();
+        $familyId = $this->createProductFamily();
+
+        $this->client->request(
+            'POST',
+            '/admin/api/products.json?locale=en',
+            [],
+            [],
+            [],
+            \json_encode([
+                'locale' => 'en',
+                'title' => 'Variant Parent Product',
+                'url' => '/test-variant-parent-product',
+                'productFamily' => $familyId,
+                'type' => ProductInterface::TYPE_PRODUCT_WITH_VARIANTS,
+            ]) ?: null,
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+
+        $data = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+        $id = $data['id'];
+        $this->assertIsString($id);
+
+        /** @var RouteRepositoryInterface $routeRepository */
+        $routeRepository = self::getContainer()->get(RouteRepositoryInterface::class);
+
+        $this->assertFalse($routeRepository->existBy([
+            'resourceKey' => ProductInterface::RESOURCE_KEY,
+            'resourceId' => $id,
+            'locale' => 'en',
+        ]));
+    }
+
     public function testGet(): void
     {
         self::purgeDatabase();

--- a/tests/Functional/Integration/ProductControllerTest.php
+++ b/tests/Functional/Integration/ProductControllerTest.php
@@ -24,6 +24,7 @@ use Sulu\Product\Domain\Repository\AttributeGroupRepositoryInterface;
 use Sulu\Product\Domain\Repository\AttributeRepositoryInterface;
 use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
 use Sulu\Product\UserInterface\Controller\Admin\ProductController;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 #[CoversClass(ProductController::class)]
@@ -91,13 +92,14 @@ class ProductControllerTest extends SuluTestCase
             [],
             [],
             [],
-            \json_encode([
+            \json_encode(\array_filter([
                 'locale' => 'en',
                 'title' => $title,
-                'url' => '/test-product-' . $counter,
+                // a product with variants shows no route field, its variants carry the routes
+                'url' => ProductInterface::TYPE_PRODUCT_WITH_VARIANTS === $type ? null : '/test-product-' . $counter,
                 'productFamily' => $familyId,
                 'type' => $type,
-            ]) ?: null,
+            ], static fn ($value) => null !== $value)) ?: null,
         );
         $this->assertHttpStatusCode(201, $this->client->getResponse());
         $data = \json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -198,6 +200,30 @@ class ProductControllerTest extends SuluTestCase
         $id = $data['id'];
         $this->assertIsString($id);
         $this->assertNotEmpty($id);
+    }
+
+    public function testPostProductWithVariantsWithoutUrlCreatesNoRoute(): void
+    {
+        self::purgeDatabase();
+        $familyId = $this->createProductFamily();
+
+        $productId = $this->createProduct($familyId, 'Plain Product');
+        $withVariantsId = $this->createProduct($familyId, 'Variant Parent Product', ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+
+        /** @var RouteRepositoryInterface $routeRepository */
+        $routeRepository = self::getContainer()->get(RouteRepositoryInterface::class);
+
+        $this->assertTrue($routeRepository->existBy([
+            'resourceKey' => ProductInterface::RESOURCE_KEY,
+            'resourceId' => $productId,
+            'locale' => 'en',
+        ]));
+
+        $this->assertFalse($routeRepository->existBy([
+            'resourceKey' => ProductInterface::RESOURCE_KEY,
+            'resourceId' => $withVariantsId,
+            'locale' => 'en',
+        ]));
     }
 
     public function testGet(): void

--- a/tests/Functional/Integration/ProductVariantControllerTest.php
+++ b/tests/Functional/Integration/ProductVariantControllerTest.php
@@ -106,13 +106,14 @@ class ProductVariantControllerTest extends SuluTestCase
             [],
             [],
             [],
-            \json_encode([
+            \json_encode(\array_filter([
                 'locale' => 'en',
                 'title' => $title,
-                'url' => '/test-product-' . $counter,
+                // a product with variants shows no route field, its variants carry the routes
+                'url' => ProductInterface::TYPE_PRODUCT_WITH_VARIANTS === $type ? null : '/test-product-' . $counter,
                 'productFamily' => $familyId,
                 'type' => $type,
-            ]) ?: null,
+            ], static fn ($value) => null !== $value)) ?: null,
         );
         $this->assertHttpStatusCode(201, $this->client->getResponse());
         $data = \json_decode((string) $this->client->getResponse()->getContent(), true);

--- a/tests/Unit/Domain/Model/ProductDimensionContentTest.php
+++ b/tests/Unit/Domain/Model/ProductDimensionContentTest.php
@@ -24,6 +24,7 @@ use Sulu\Product\Domain\Model\ProductAttributeValue;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductFamily;
 use Sulu\Product\Domain\Model\ProductInterface;
+use Sulu\Route\Domain\Model\Route;
 
 #[CoversClass(ProductDimensionContent::class)]
 class ProductDimensionContentTest extends TestCase
@@ -57,6 +58,16 @@ class ProductDimensionContentTest extends TestCase
     public function testIsRouteMandatoryReturnsFalse(): void
     {
         $this->assertFalse(ProductDimensionContent::isRouteMandatory());
+    }
+
+    public function testRemoveRouteDropsTheRoute(): void
+    {
+        $dimensionContent = new ProductDimensionContent(new Product());
+        $dimensionContent->setRoute(new Route('products', '1', 'en', '/products/my-product'));
+
+        $dimensionContent->removeRoute();
+
+        $this->assertNull($dimensionContent->getRoute());
     }
 
     public function testSetTemplateDataExtractsTitle(): void

--- a/tests/Unit/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuardTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuardTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Unit\Infrastructure\Doctrine\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Product\Domain\Model\Product;
+use Sulu\Product\Domain\Model\ProductDimensionContent;
+use Sulu\Product\Domain\Model\ProductInterface;
+use Sulu\Product\Infrastructure\Doctrine\EventListener\ProductWithVariantsRouteGuard;
+use Sulu\Route\Domain\Model\Route;
+
+#[CoversClass(ProductWithVariantsRouteGuard::class)]
+class ProductWithVariantsRouteGuardTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<UnitOfWork>
+     */
+    private ObjectProphecy $unitOfWork;
+
+    /**
+     * @var ObjectProphecy<EntityManagerInterface>
+     */
+    private ObjectProphecy $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->unitOfWork = $this->prophesize(UnitOfWork::class);
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $this->entityManager->getUnitOfWork()->willReturn($this->unitOfWork->reveal());
+        $this->entityManager->getClassMetadata(Argument::type('string'))
+            ->willReturn(new ClassMetadata(ProductDimensionContent::class));
+    }
+
+    public function testDropsTheRouteOfAProductWithVariants(): void
+    {
+        $dimensionContent = $this->createDimensionContent(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+        $route = $this->createRoute();
+        $dimensionContent->setRoute($route);
+
+        $this->schedule(insertions: [$dimensionContent]);
+        $this->unitOfWork->isScheduledForInsert($dimensionContent)->willReturn(true);
+        $this->unitOfWork->isScheduledForInsert($route)->willReturn(true);
+        $this->unitOfWork->computeChangeSet(Argument::any(), $dimensionContent)->shouldBeCalled();
+        $this->entityManager->detach($route)->shouldBeCalled();
+
+        $this->guard()->onFlush(new OnFlushEventArgs($this->entityManager->reveal()));
+
+        $this->assertNull($dimensionContent->getRoute());
+    }
+
+    public function testDropsTheRouteOnUpdateWithoutDetachingAPersistedRoute(): void
+    {
+        $dimensionContent = $this->createDimensionContent(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+        $route = $this->createRoute();
+        $dimensionContent->setRoute($route);
+
+        $this->schedule(updates: [$dimensionContent]);
+        $this->unitOfWork->isScheduledForInsert($dimensionContent)->willReturn(false);
+        $this->unitOfWork->isScheduledForInsert($route)->willReturn(false);
+        $this->unitOfWork->recomputeSingleEntityChangeSet(Argument::any(), $dimensionContent)->shouldBeCalled();
+        $this->entityManager->detach(Argument::any())->shouldNotBeCalled();
+
+        $this->guard()->onFlush(new OnFlushEventArgs($this->entityManager->reveal()));
+
+        $this->assertNull($dimensionContent->getRoute());
+    }
+
+    public function testKeepsTheRouteOfAPlainProduct(): void
+    {
+        $dimensionContent = $this->createDimensionContent(ProductInterface::TYPE_PRODUCT);
+        $route = $this->createRoute();
+        $dimensionContent->setRoute($route);
+
+        $this->schedule(insertions: [$dimensionContent]);
+        $this->unitOfWork->computeChangeSet(Argument::cetera())->shouldNotBeCalled();
+        $this->unitOfWork->recomputeSingleEntityChangeSet(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->detach(Argument::any())->shouldNotBeCalled();
+
+        $this->guard()->onFlush(new OnFlushEventArgs($this->entityManager->reveal()));
+
+        $this->assertSame($route, $dimensionContent->getRoute());
+    }
+
+    public function testIgnoresAProductWithVariantsWithoutRoute(): void
+    {
+        $dimensionContent = $this->createDimensionContent(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+
+        $this->schedule(insertions: [$dimensionContent]);
+        $this->unitOfWork->computeChangeSet(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->detach(Argument::any())->shouldNotBeCalled();
+
+        $this->guard()->onFlush(new OnFlushEventArgs($this->entityManager->reveal()));
+
+        $this->assertNull($dimensionContent->getRoute());
+    }
+
+    public function testIgnoresOtherEntities(): void
+    {
+        $this->schedule(insertions: [new \stdClass()], updates: [$this->createRoute()]);
+        $this->entityManager->detach(Argument::any())->shouldNotBeCalled();
+
+        $this->guard()->onFlush(new OnFlushEventArgs($this->entityManager->reveal()));
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function guard(): ProductWithVariantsRouteGuard
+    {
+        return new ProductWithVariantsRouteGuard();
+    }
+
+    private function createDimensionContent(string $type): ProductDimensionContent
+    {
+        $product = new Product();
+        $product->setType($type);
+
+        $dimensionContent = new ProductDimensionContent($product);
+        $dimensionContent->setLocale('en');
+
+        return $dimensionContent;
+    }
+
+    private function createRoute(): Route
+    {
+        return new Route('products', '1', 'en', '/products/my-product');
+    }
+
+    /**
+     * @param object[] $insertions
+     * @param object[] $updates
+     */
+    private function schedule(array $insertions = [], array $updates = []): void
+    {
+        $this->unitOfWork->getScheduledEntityInsertions()->willReturn($insertions);
+        $this->unitOfWork->getScheduledEntityUpdates()->willReturn($updates);
+    }
+}

--- a/tests/Unit/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuardTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/EventListener/ProductWithVariantsRouteGuardTest.php
@@ -59,9 +59,10 @@ class ProductWithVariantsRouteGuardTest extends TestCase
         $dimensionContent->setRoute($route);
 
         $this->schedule(insertions: [$dimensionContent]);
-        $this->unitOfWork->isScheduledForInsert($dimensionContent)->willReturn(true);
         $this->unitOfWork->isScheduledForInsert($route)->willReturn(true);
-        $this->unitOfWork->computeChangeSet(Argument::any(), $dimensionContent)->shouldBeCalled();
+        // computeChangeSet() would replace the insert's full changeset with a one-field diff.
+        $this->unitOfWork->computeChangeSet(Argument::cetera())->shouldNotBeCalled();
+        $this->unitOfWork->recomputeSingleEntityChangeSet(Argument::any(), $dimensionContent)->shouldBeCalled();
         $this->entityManager->detach($route)->shouldBeCalled();
 
         $this->guard()->onFlush(new OnFlushEventArgs($this->entityManager->reveal()));
@@ -76,7 +77,6 @@ class ProductWithVariantsRouteGuardTest extends TestCase
         $dimensionContent->setRoute($route);
 
         $this->schedule(updates: [$dimensionContent]);
-        $this->unitOfWork->isScheduledForInsert($dimensionContent)->willReturn(false);
         $this->unitOfWork->isScheduledForInsert($route)->willReturn(false);
         $this->unitOfWork->recomputeSingleEntityChangeSet(Argument::any(), $dimensionContent)->shouldBeCalled();
         $this->entityManager->detach(Argument::any())->shouldNotBeCalled();

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
@@ -120,15 +120,6 @@ class ProductRouteFormMetadataVisitorTest extends TestCase
         $visitor->visitFormMetadata($form, 'en', []);
 
         self::assertTrue($routeField->isRequired());
-
-        // the merge nests the added constraint as an `allOf` branch
-        $schema = $form->getSchema()->toJsonSchema();
-        self::assertIsArray($schema);
-        self::assertContains([
-            'type' => 'object',
-            'properties' => ['url' => ['type' => 'string', 'minLength' => 1]],
-            'required' => ['url'],
-        ], $schema['allOf'] ?? []);
     }
 
     public function testDoesNotRequireTheRouteOnTheDetailsForm(): void
@@ -144,7 +135,6 @@ class ProductRouteFormMetadataVisitorTest extends TestCase
         $visitor->visitFormMetadata($form, 'en', []);
 
         self::assertFalse($routeField->isRequired());
-        self::assertStringNotContainsString('url', (string) \json_encode($form->getSchema()->toJsonSchema()));
     }
 
     public function testIgnoresOtherForms(): void

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
@@ -152,8 +153,34 @@ class ProductRouteFormMetadataVisitorTest extends TestCase
         self::assertSame('route', $routeField->getType());
         self::assertSame('false', $routeField->getVisibleCondition());
         self::assertSame('/products/{implode(\'-\', object)}', $routeField->getOptions()['route_schema']->getValue());
+        self::assertTrue($routeField->hasTag('sulu.rlp'));
         // the slug belongs to the route entity, never to the template data
         self::assertTrue($routeField->hasTag(TemplateDataMapper::SKIP_TAG));
+    }
+
+    public function testMergesTagsTheTemplateDeclares(): void
+    {
+        $declaredTag = new TagMetadata();
+        $declaredTag->setName('sulu.rlp');
+        $declaredTag->setPriority(1);
+
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+        $routeField->addTag($declaredTag);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $form = new FormMetadata();
+        $form->setKey('product');
+        $form->addItem($routeField);
+        $typedFormMetadata->addForm('product', $form);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', ['route_schema' => '/products']);
+        $visitor->visitTypedFormMetadata($typedFormMetadata, ProductDimensionContent::getTemplateType(), 'en');
+        $visitor->visitTypedFormMetadata($typedFormMetadata, ProductDimensionContent::getTemplateType(), 'en');
+
+        $tagNames = \array_map(static fn (TagMetadata $tag): string => $tag->getName(), $routeField->getTags());
+        self::assertSame(['sulu.rlp', TemplateDataMapper::SKIP_TAG], $tagNames);
+        self::assertSame(1, $declaredTag->getPriority());
     }
 
     public function testKeepsARouteFieldTheTemplateDeclares(): void

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
@@ -107,6 +107,46 @@ class ProductRouteFormMetadataVisitorTest extends TestCase
         self::assertSame('/products/{implode(\'-\', object)}', $routeField->getOptions()['route_schema']->getValue());
     }
 
+    public function testRequiresTheRouteOnTheVariantOverlay(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $form = new FormMetadata();
+        $form->setKey('product_variant');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', []);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertTrue($routeField->isRequired());
+
+        // the merge nests the added constraint as an `allOf` branch
+        $schema = $form->getSchema()->toJsonSchema();
+        self::assertIsArray($schema);
+        self::assertContains([
+            'type' => 'object',
+            'properties' => ['url' => ['type' => 'string', 'minLength' => 1]],
+            'required' => ['url'],
+        ], $schema['allOf'] ?? []);
+    }
+
+    public function testDoesNotRequireTheRouteOnTheDetailsForm(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', []);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertFalse($routeField->isRequired());
+        self::assertStringNotContainsString('url', (string) \json_encode($form->getSchema()->toJsonSchema()));
+    }
+
     public function testIgnoresOtherForms(): void
     {
         $routeField = new FieldMetadata('url');

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
@@ -17,6 +17,9 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
+use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductRouteFormMetadataVisitor;
 
 class ProductRouteFormMetadataVisitorTest extends TestCase
@@ -127,6 +130,61 @@ class ProductRouteFormMetadataVisitorTest extends TestCase
 
         $visitor = new ProductRouteFormMetadataVisitor('route', ['route_schema' => '/products']);
         $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame([], $form->getItems());
+    }
+
+    public function testAddsInvisibleRouteFieldToProductTemplates(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        $form = new FormMetadata();
+        $form->setKey('product');
+        $form->addItem(new FieldMetadata('title'));
+        $typedFormMetadata->addForm('product', $form);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', [
+            'route_schema' => '/products/{implode(\'-\', object)}',
+        ]);
+        $visitor->visitTypedFormMetadata($typedFormMetadata, ProductDimensionContent::getTemplateType(), 'en');
+
+        $routeField = $form->getItems()['url'] ?? null;
+        self::assertInstanceOf(FieldMetadata::class, $routeField);
+        self::assertSame('route', $routeField->getType());
+        self::assertSame('false', $routeField->getVisibleCondition());
+        self::assertSame('/products/{implode(\'-\', object)}', $routeField->getOptions()['route_schema']->getValue());
+        // the slug belongs to the route entity, never to the template data
+        self::assertTrue($routeField->hasTag(TemplateDataMapper::SKIP_TAG));
+    }
+
+    public function testKeepsARouteFieldTheTemplateDeclares(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $form = new FormMetadata();
+        $form->setKey('product');
+        $form->addItem($routeField);
+        $typedFormMetadata->addForm('product', $form);
+
+        $visitor = new ProductRouteFormMetadataVisitor('page_tree_route', ['route_schema' => '/products']);
+        $visitor->visitTypedFormMetadata($typedFormMetadata, ProductDimensionContent::getTemplateType(), 'en');
+
+        self::assertSame($routeField, $form->getItems()['url']);
+        self::assertSame('page_tree_route', $routeField->getType());
+        // a declared field stays visible, only the injected one is hidden
+        self::assertNull($routeField->getVisibleCondition());
+    }
+
+    public function testIgnoresOtherTemplateTypes(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        $form = new FormMetadata();
+        $form->setKey('default');
+        $typedFormMetadata->addForm('default', $form);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', ['route_schema' => '/products']);
+        $visitor->visitTypedFormMetadata($typedFormMetadata, 'page', 'en');
 
         self::assertSame([], $form->getItems());
     }

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductRouteFormMetadataVisitor;
+
+class ProductRouteFormMetadataVisitorTest extends TestCase
+{
+    public function testAppliesConfiguredTypeAndParams(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('page_tree_route', [
+            'route_schema' => '/products/{implode(\'-\', object)}',
+            'available_locales' => true,
+        ]);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame('page_tree_route', $routeField->getType());
+
+        $options = $routeField->getOptions();
+        self::assertArrayHasKey('route_schema', $options);
+        self::assertSame('/products/{implode(\'-\', object)}', $options['route_schema']->getValue());
+        self::assertArrayHasKey('available_locales', $options);
+        self::assertTrue($options['available_locales']->getValue());
+    }
+
+    public function testConfiguredParamReplacesTheOneOfTheForm(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $formOption = new OptionMetadata();
+        $formOption->setName('route_schema');
+        $formOption->setValue('/{implode(\'-\', object)}');
+        $routeField->addOption($formOption);
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', ['route_schema' => '/products/{object[\'code\']}']);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame('/products/{object[\'code\']}', $routeField->getOptions()['route_schema']->getValue());
+    }
+
+    public function testKeepsFormParamsWhichAreNotConfigured(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $formOption = new OptionMetadata();
+        $formOption->setName('mode');
+        $formOption->setValue('leaf');
+        $routeField->addOption($formOption);
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', ['route_schema' => '/products/{object[\'code\']}']);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame('leaf', $routeField->getOptions()['mode']->getValue());
+    }
+
+    public function testAppliesConfiguredTypeAndParamsToVariantOverlay(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $form = new FormMetadata();
+        $form->setKey('product_variant');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('page_tree_route', [
+            'route_schema' => '/products/{implode(\'-\', object)}',
+        ]);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame('page_tree_route', $routeField->getType());
+        self::assertSame('/products/{implode(\'-\', object)}', $routeField->getOptions()['route_schema']->getValue());
+    }
+
+    public function testIgnoresOtherForms(): void
+    {
+        $routeField = new FieldMetadata('url');
+        $routeField->setType('route');
+
+        $form = new FormMetadata();
+        $form->setKey('some_other_form');
+        $form->addItem($routeField);
+
+        $visitor = new ProductRouteFormMetadataVisitor('page_tree_route', ['route_schema' => '/products']);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame('route', $routeField->getType());
+        self::assertSame([], $routeField->getOptions());
+    }
+
+    public function testIgnoresProductDetailsFormWithoutRouteField(): void
+    {
+        // A consumer that removed the route field from the form: the visitor must no-op, not blow up.
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+
+        $visitor = new ProductRouteFormMetadataVisitor('route', ['route_schema' => '/products']);
+        $visitor->visitFormMetadata($form, 'en', []);
+
+        self::assertSame([], $form->getItems());
+    }
+}

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductRouteFormMetadataVisitorTest.php
@@ -186,6 +186,16 @@ class ProductRouteFormMetadataVisitorTest extends TestCase
         self::assertTrue($routeField->hasTag('sulu.rlp'));
         // the slug belongs to the route entity, never to the template data
         self::assertTrue($routeField->hasTag(TemplateDataMapper::SKIP_TAG));
+
+        $searchTag = null;
+        foreach ($routeField->getTags() as $tag) {
+            if (TagMetadata::SEARCH_FIELD_TAG === $tag->getName()) {
+                $searchTag = $tag;
+            }
+        }
+
+        self::assertInstanceOf(TagMetadata::class, $searchTag);
+        self::assertSame('url', $searchTag->getAttribute('role'));
     }
 
     public function testMergesTagsTheTemplateDeclares(): void

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -33,6 +33,7 @@
     "sulu_product.product_type_product_with_variants": "Produkt mit Varianten",
     "sulu_product.product_type_variant": "Variante",
     "sulu_product.code": "Code",
+    "sulu_product.url": "Adresse",
     "sulu_product.external_identifier": "External Identifier",
     "sulu_product.options": "Optionen",
     "sulu_product.no_product_selected": "Kein Produkt ausgewählt",

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -33,6 +33,7 @@
     "sulu_product.product_type_product_with_variants": "Product with variants",
     "sulu_product.product_type_variant": "Variant",
     "sulu_product.code": "Code",
+    "sulu_product.url": "URL",
     "sulu_product.external_identifier": "External Identifier",
     "sulu_product.options": "Options",
     "sulu_product.no_product_selected": "No product selected",


### PR DESCRIPTION
fixes #415 ( just simple case )

The route field of a product no longer lives in the product template but in the `product_details`
form and the `product_variant` overlay. Its field type and its params come from a new
`sulu_product.route` config, applied by a form metadata visitor, so a project configures the route
once instead of per template:

```yaml
sulu_product:
    route:
        type: route # default, e.g. "page_tree_route" for a route below a page
        params:
            route_schema: "/products/{implode('-', object)}" # default
```

`params` takes any key the configured field type understands and forwards it to the field as-is.
A configured param wins over the one the form declares and over the default of the same key, so a
project states only what it changes.

The same visitor adds the field invisibly to every product template, because
[`RoutableDataMapper`](https://github.com/sulu/sulu/blob/3.0/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php#L75)
reads the route property off the template metadata. That field carries the skip tag of
`TemplateDataMapper`, so the slug stays with the route entity.

A product with variants is reached through its variants and owns no route of its own:

* the field is hidden on `product_details` for that type
* `ProductWithVariantsRouteGuard`, a doctrine `onFlush` listener, drops a route that reaches such a
  dimension content programmatically and detaches one the same flush would insert
* on the variant overlay the route is mandatory instead, set through the visitor together with a
  merged schema constraint, because the schema is built before the visitors run

What to check: the config reaches both forms, the URL generates from the title, a saved product
gets its route, and a product with variants gets none.

## Out of scope

A variant still resolves to its parent URL plus `?variant=`. Replacing
that with the real variant URLs and removing `sulu_product.variant_query_parameter` belongs in a
separate pull request, this one keeps the current behaviour.

Let this follow up on the resolving part handled by @martinlagler or @Prokyonn .

---

I also update the Form so Mandatory fields are at the top, the type has the most effects and need to be the first field:

<img width="1123" height="627" alt="Bildschirmfoto 2026-09-09 um 18 31 51" src="https://github.com/user-attachments/assets/aea1f8a9-51ce-406f-ae30-d85424c4b519" />

